### PR TITLE
Disable pip cache dir in Python template

### DIFF
--- a/project/python/{{ cookiecutter.project_name }}/Dockerfile
+++ b/project/python/{{ cookiecutter.project_name }}/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt --no-cache-dir
 COPY . .
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .


### PR DESCRIPTION
The pip cache makes the images larger and is not needed, it's better to disable it. This is already addressed in the existing PySpark template.