### PR TITLE
Update dbt image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 <a name="unreleased"></a>
 
 ## Unreleased
+
 ### features
 - Support duckdb when creating dbt projects
-- Upgrade the dbt image to use dbt 1.4.0
+- Upgrade the dbt image to use dbt 1.4.0-1
 - Add a dbt resources template
 
 ## [1.2.0 - 2023-02-01]

--- a/project/dbt/{{ cookiecutter.project_name }}/Dockerfile
+++ b/project/dbt/{{ cookiecutter.project_name }}/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/dataminded/dbt:v1.4.0
+FROM public.ecr.aws/dataminded/dbt:v1.4.0-1
 
 WORKDIR /app
 COPY . .

--- a/project/dbt/{{ cookiecutter.project_name }}/Makefile
+++ b/project/dbt/{{ cookiecutter.project_name }}/Makefile
@@ -5,13 +5,13 @@ rel_profiles_dir:=dbt
 abs_project_dir:=$(current_dir)/$(rel_project_dir)
 abs_profiles_dir:=$(current_dir)/$(rel_profiles_dir)
 env_file:=$(current_dir)/.env
-dbt_version:=v1.4.0
+dbt_image_version:=v1.4.0-1
 os_docker_flag:=
 ifeq ($(shell uname -s),Linux)
 	os_docker_flag += --add-host host.docker.internal:host-gateway
 endif
-docker_dbt_shell_command:=docker run --rm $(os_docker_flag) --env-file $(env_file) --entrypoint /bin/bash --privileged -it -e NO_DOCKER=1 --network=host -v $(current_dir):/workspace -w /workspace public.ecr.aws/dataminded/dbt:$(dbt_version)
-docker_dbt_command:=docker run --rm $(os_docker_flag) --env-file $(env_file) -it -v $(current_dir):/workspace -w /workspace public.ecr.aws/dataminded/dbt:$(dbt_version)
+docker_dbt_shell_command:=docker run --rm $(os_docker_flag) --env-file $(env_file) --entrypoint /bin/bash --privileged -it -e NO_DOCKER=1 --network=host -v $(current_dir):/workspace -w /workspace public.ecr.aws/dataminded/dbt:$(dbt_image_version)
+docker_dbt_command:=docker run --rm $(os_docker_flag) --env-file $(env_file) -it -v $(current_dir):/workspace -w /workspace public.ecr.aws/dataminded/dbt:$(dbt_image_version)
 
 supported_args=target models select
 args = $(foreach a,$(supported_args),$(if $(value $a),--$a "$($a)"))


### PR DESCRIPTION
Add trino to base image such that make manifest works out of the box.

- [x] I have updated te CHANGELOG.md

## Why are the changes needed?
Allow one of our customers to use Trino and all dbt functionality works out of the box.
Since Trino is a custom adapter, which we did not yet package in our dbt image, it is otherwise difficult to get the `make manifest` command to work.

## How was this tested?
Manual validation